### PR TITLE
Fix typographical error(s)

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ by the name of the kit.
 There is a picture with name of each of the items in the kit
 entitled 35Sensor.jpg.  Evidently 2 sensors are missing from 
 the picture list.  No guarantee that the name from the picture
-corrisponds to the name of the folder.
+corresponds to the name of the folder.
 
 There is a 37-1.pdf file that has a little info and sketches for
 every project.  It appeared to translated from another language,


### PR DESCRIPTION
@BuckRogers1965, I've corrected a typographical error in the documentation of the [Sunfounder-37-Sensor-Kit](https://github.com/BuckRogers1965/Sunfounder-37-Sensor-Kit) project. Specifically, I've changed corrispond to correspond. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.
